### PR TITLE
adding suppot for serverside mocha tests, they should be in modular form...

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -28,14 +28,18 @@ module.exports = (grunt) ->
         sourceMap: true
       compile:
         files:
-          "public/js/testAllTheThings.js": ["public/coffee/client.coffee"]
-          
+          "public/js/testAllTheThings.js": ["public/coffee/client.coffee"]     
       client_specs:
         files: grunt.file.expandMapping(["specs/client/*.coffee"], "specs/client/js/", {
           rename: (destBase, destPath) ->
             destBase + destPath.replace(/\.coffee$/, ".js").replace(/specs\//, "")
         })
-    
+      server_specs:
+        files: grunt.file.expandMapping(["specs/server/*.coffee"], "specs/server/", {
+          rename: (destBase, destPath) ->
+            destBase + destPath.replace(/\.coffee$/, ".js").replace(/specs\/server\//, "")
+        })
+
     concat:
       js:
         src: ["src-client/js/libs/*.js", "src-client/js/libs/cm-modes/**/*.js"]
@@ -64,7 +68,7 @@ module.exports = (grunt) ->
         
     cafemocha:
       testThis:
-        src: "specs/server/*.coffee"
+        src: "specs/server/*Spec.js"
         options:
           ui: "tdd"
           # require: [ "should" ]
@@ -90,7 +94,7 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks "grunt-exec"
 
   # Clean, compile and concatenate JS
-  grunt.registerTask "coffeescript", [ "exec:copyCoffee", "coffee", "concat:js", "jasmine:client", "cafemocha" ]
+  grunt.registerTask "coffeescript", [ "exec:copyCoffee", "coffee", "concat:js", "cafemocha", "jasmine:client" ]
 
   # Clean and compile stylesheets
   grunt.registerTask "stylesheets", [ "compass" ]

--- a/app.coffee
+++ b/app.coffee
@@ -1,4 +1,3 @@
-
 ###
 Module dependencies.
 ###
@@ -64,3 +63,5 @@ app.post "/creategist", (req, res) ->
 
 app.listen 3030
 console.log "Go to http://localhost:3030"
+
+module.exports = usersById

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "hiredis": "~0.1.15",
     "connect-redis": "~1.4.5",
     "connect": "~2.7.3",
-    "phantomjs" : "1.8.2-0"
+    "phantomjs": "1.8.2-0"
   },
   "devDependencies": {
     "node-jade-compress": "0.0.15",
@@ -27,11 +27,9 @@
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-exec": "~0.4.0",
     "grunt-jasmine": "~0.1.0",
-<<<<<<< HEAD
-    "grunt-cafe-mocha": "~0.1.1"
-=======
-    "grunt-jasmine-node": "0.0.6",
-    "grunt-contrib-jasmine": "~0.4.1"
->>>>>>> 26f513996bbc45ca88f02402fd9ce3d0428bbef7
+    "grunt-cafe-mocha": "~0.1.1",
+    "grunt-contrib-jasmine": "~0.4.2",
+    "jsdom": "~0.5.5",
+    "expect.js": "~0.2.0"
   }
 }

--- a/specs/server/appSpec.coffee
+++ b/specs/server/appSpec.coffee
@@ -1,5 +1,6 @@
-require "../../app.coffee"
+usersById = require "../../app.coffee"
+expect = require "expect.js"
 
 describe "server testing", ->
    it "should work", ->
-     expect(usersById).toBe {1:1}
+     expect(typeof usersById).to.be("object")


### PR DESCRIPTION
This is a little obtuse, but it does successfully test using expect.js. and grunt-cafe-mocha. 

Right now, I am temporarily passing the appSpec.coffee with a hack. We should wrap the app.coffee in a class and expose it at the end for the require. I am not sure how else to get require to work in this instance since all of the coffeescript specs are being compiled before the mocha test run. 

There is definately a lack of this in the grunt-cafe-mocha package. 
